### PR TITLE
Fixed incompatibility with PHP 7.2+

### DIFF
--- a/cache.php
+++ b/cache.php
@@ -384,12 +384,15 @@ function hyper_mobile_type() {
 		return '';
 
 	$hyper_agent = strtolower($_SERVER['HTTP_USER_AGENT']);
-	foreach ($hyper_cache['mobile_agents'] as $hyper_a) {
-		if (strpos($hyper_agent, $hyper_a) !== false) {
-			if (strpos($hyper_agent, 'iphone') || strpos($hyper_agent, 'ipod')) {
-				return 'iphone';
-			} else {
-				return 'pda';
+	$mobile_agents = $hyper_cache['mobile_agents'];
+	if (is_array($mobile_agents) || is_object($mobile_agents)) {
+		foreach ($mobile_agents as $hyper_a) {
+			if (strpos($hyper_agent, $hyper_a) !== false) {
+				if (strpos($hyper_agent, 'iphone') || strpos($hyper_agent, 'ipod')) {
+					return 'iphone';
+				} else {
+					return 'pda';
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The **"Hyper Cache Extended" plugin** for WordPress (version 1.6.3) is **not compatible with PHP 7.2**, PHP 7.3 and later. It produces a **Warning** at line 492 in `cache.php`, like this:

```
Warning: Invalid argument supplied for foreach() in /.../wp-content/plugins/hyper-cache-extended/cache.php on line 392
```

This is because in PHP 7.2+ the `foreach` loop no longer supports iterating over null / missing / invalid collections. You need to add a check for null or invalid collection. This is what I added in this pull request.

See detailed bug report here: https://wordpress.org/support/topic/hyper-cache-extended-not-compatible-with-php-7-2